### PR TITLE
Adds Anaconda to build tools in Dockerfile and updates documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV MAVEN_VERSION 3.3.9
 ENV NODE_VERSION 10
 ENV HELM_VERSION 2.9.1
 ENV CLOUD_SDK_REPO cloud-sdk-cosmic
-
+ENV PATH /opt/conda/bin:$PATH
 
 # Prereqs
 RUN apt-get update && apt-get install -qq \
@@ -66,6 +66,14 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst fonts-freefont-ttf \
     --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
+
+# Anaconda
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+    /bin/bash ~/anaconda.sh -b -p /opt/conda && \
+    rm ~/anaconda.sh && \
+    ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
+    echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
+    echo "conda activate base" >> ~/.bashrc
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The build tools included are:
 - **Kubectl** 2019.09.27
 - **Ansible** 2.8.5
 - **Chrome** 80.0.3962.2 dev
+- **Anaconda3** 5.3.0
 
 ## Use
 
@@ -76,6 +77,7 @@ Licenses for the products installed within the images:
 - GCloud/Kubectl: Apache License, Version 2.0. and [GCloud Terms](https://cloud.google.com/terms/)
 - Ansible: [GPL v3.0](https://github.com/ansible/ansible/blob/devel/COPYING)
 - Google Chrome [EULA](https://www.google.com/intl/en_sg/chrome/privacy/eula_text.html)
+- Anaconda [EULA](https://docs.anaconda.com/anaconda/eula/)
 
 As with all Docker images, other software is likely to be included, which might be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/test.sh
+++ b/test.sh
@@ -8,3 +8,5 @@ docker run --rm committed/ci gcloud --version
 echo "Helm version $(docker run --rm committed/ci helm version -c --short)"
 docker run --rm committed/ci ansible --version
 docker run --rm committed/ci google-chrome --version
+docker run --rm committed/ci conda --version
+docker run --rm committed/ci python -V


### PR DESCRIPTION
Adds Anaconda for Python 3 to the build tools on the Docker image.

This doesnt seem to clash with Ansible from basic version tests.