### PR TITLE
Add Docker-Compose, AWS & Upgrade Node, Java

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,6 @@ steps:
     commands:
       - docker build -t committed/ci:ci .
       - docker run --rm committed/ci:ci /ci_tests.sh
-      - docker image rm committed/ci:ci
     volumes:
       - name: docker_sock
         path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: committed-ci
+name: committed-ci:1.4.0
 
 volumes:
   - name: docker_sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,8 +12,9 @@ steps:
   - name: build-and-test
     image: committed/ci
     commands:
-      - ./build.sh
-      - ./test.sh
+      - docker build -t committed/ci:ci .
+      - docker run --rm committed/ci:ci /ci_tests.sh
+      - docker image rm committed/ci:ci
     volumes:
       - name: docker_sock
         path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,26 @@
+---
+kind: pipeline
+type: docker
+name: committed-ci
+
+volumes:
+  - name: docker_sock
+    host:
+      path: /var/run/docker.sock
+
+steps:
+  - name: build
+    image: committed/ci
+    commands:
+      - ./build.sh
+    volumes:
+      - name: docker_sock
+        path: /var/run/docker.sock
+    
+  - name: test
+    image: committed/ci
+    commands:
+      - ./test.sh
+    volumes:
+      - name: docker_sock
+        path: /var/run/docker.sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,17 +9,10 @@ volumes:
       path: /var/run/docker.sock
 
 steps:
-  - name: build
+  - name: build-and-test
     image: committed/ci
     commands:
       - ./build.sh
-    volumes:
-      - name: docker_sock
-        path: /var/run/docker.sock
-    
-  - name: test
-    image: committed/ci
-    commands:
       - ./test.sh
     volumes:
       - name: docker_sock

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 ---
 kind: pipeline
 type: docker
-name: committed-ci:1.4.0
+name: committed-ci
 
 volumes:
   - name: docker_sock

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV MAVEN_VERSION 3.3.9
 ENV NODE_VERSION 10
 ENV HELM_VERSION 2.9.1
 ENV DOCKER_VERSION=19.03.7
+ENV DOCKER_COMPOSE_VERSION=1.25.4
 ENV CLOUD_SDK_REPO cloud-sdk-cosmic
 ENV PATH /opt/conda/bin:$PATH
 
@@ -80,6 +81,16 @@ RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.
 RUN wget --quiet https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz && \
     tar -xzvf docker-${DOCKER_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
     rm docker-${DOCKER_VERSION}.tgz
+
+# Docker-compose
+RUN curl -s -L "https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/docker-compose
+
+# AWS
+RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip -q awscliv2.zip && \
+    ./aws/install && \
+    rm awscliv2.zip
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk13:ubuntu
+FROM adoptopenjdk/openjdk13:openjdk13:jdk-13_33-ubuntu
 LABEL maintainer="Committed Software <docker@committed.software>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk13:openjdk13:jdk-13_33-ubuntu
+FROM adoptopenjdk/openjdk13:jdk-13_33-ubuntu
 LABEL maintainer="Committed Software <docker@committed.software>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ LABEL maintainer="Committed Software <docker@committed.software>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ENV NODE_VERSION 10
+ENV NODE_VERSION 12
 ENV HELM_VERSION 2.9.1
 ENV ANACONDA3_VERSION 5.3.0
 ENV DOCKER_VERSION=19.03.7

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV NODE_VERSION 10
 ENV HELM_VERSION 2.9.1
+ENV ANACONDA3_VERSION 5.3.0
 ENV DOCKER_VERSION=19.03.7
 ENV DOCKER_COMPOSE_VERSION=1.25.4
 ENV CLOUD_SDK_REPO cloud-sdk-cosmic
@@ -69,7 +70,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
     && rm -rf /var/lib/apt/lists/*
 
 # Anaconda
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-${ANACONDA3_VERSION}-Linux-x86_64.sh -O ~/anaconda.sh && \
     /bin/bash ~/anaconda.sh -b -p /opt/conda && \
     rm ~/anaconda.sh && \
     ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:x86_64-ubuntu-jdk-11.0.2.9
+FROM adoptopenjdk/openjdk13:ubuntu
 LABEL maintainer="Committed Software <docker@committed.software>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -94,3 +94,6 @@ RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscl
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY ci_tests.sh /ci_tests.sh
+RUN ["chmod", "+x", "/ci_tests.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ LABEL maintainer="Committed Software <docker@committed.software>"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ENV MAVEN_VERSION 3.3.9
 ENV NODE_VERSION 10
 ENV HELM_VERSION 2.9.1
 ENV DOCKER_VERSION=19.03.7

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following general libs and utilities are installed:
 
 The build tools included are:
 
-- **Java** openjdk 11.0.2 2019-01-15
+- **Java** openjdk 13 2019-09-17
 - **Maven** Latest
 - **Node** v10.16.3
 - **Yarn** Latest

--- a/README.md
+++ b/README.md
@@ -20,19 +20,37 @@ The following general libs and utilities are installed:
 
 The build tools included are:
 
-- **Java** openjdk 13 2019-09-17
-- **Maven**
-- **Node** v10.16.3
-- **Yarn**
-- **Helm** v2.9.1
-- **GCloud**
-- **Kubectl**
-- **Ansible**
-- **Chrome**
-- **Anaconda3** 5.3.0
-- **Docker CLI** 19.03.7
-- **Docker Compose** 1.25.4
-- **AWS CLI**
+```
+openjdk 13 2019-09-17
+OpenJDK Runtime Environment AdoptOpenJDK (build 13+33)
+OpenJDK 64-Bit Server VM AdoptOpenJDK (build 13+33, mixed mode, sharing)
+Apache Maven 3.6.0
+Maven home: /usr/share/maven
+Java version: 13, vendor: AdoptOpenJDK, runtime: /opt/java/openjdk
+Default locale: en_US, platform encoding: UTF-8
+OS name: "linux", version: "4.15.0-74-generic", arch: "amd64", family: "unix"
+v12.16.1
+Yarn version 1.22.4
+Google Cloud SDK 284.0.0
+alpha 2020.03.06
+beta 2020.03.06
+bq 2.0.54
+core 2020.03.06
+gsutil 4.48
+kubectl 2020.03.06
+Helm version Client: v2.9.1+g20adb27
+ansible 2.9.6
+  config file = /etc/ansible/ansible.cfg
+  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
+  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
+  executable location = /usr/bin/ansible
+  python version = 2.7.17 (default, Nov  7 2019, 10:07:09) [GCC 7.4.0]
+Google Chrome 82.0.4083.0 dev
+conda 4.5.11
+Python 3.7.0
+Docker version 19.03.7, build 7141c199a2
+docker-compose version 1.25.4, build 8d51620a
+```
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,18 @@ The following general libs and utilities are installed:
 The build tools included are:
 
 - **Java** openjdk 13 2019-09-17
-- **Maven** Latest
+- **Maven**
 - **Node** v10.16.3
-- **Yarn** Latest
+- **Yarn**
 - **Helm** v2.9.1
-- **GCloud** Latest
-- **Kubectl** Latest
-- **Ansible** Latest
-- **Chrome** Latest
+- **GCloud**
+- **Kubectl**
+- **Ansible**
+- **Chrome**
 - **Anaconda3** 5.3.0
 - **Docker CLI** 19.03.7
 - **Docker Compose** 1.25.4
-- **AWS CLI** Latest
+- **AWS CLI**
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -21,16 +21,18 @@ The following general libs and utilities are installed:
 The build tools included are:
 
 - **Java** openjdk 11.0.2 2019-01-15
-- **Maven** v3.6.0
+- **Maven** Latest
 - **Node** v10.16.3
-- **Yarn** 1.19.0
+- **Yarn** Latest
 - **Helm** v2.9.1
-- **GCloud** 265
-- **Kubectl** 2019.09.27
-- **Ansible** 2.8.5
-- **Chrome** 80.0.3962.2 dev
+- **GCloud** Latest
+- **Kubectl** Latest
+- **Ansible** Latest
+- **Chrome** Latest
 - **Anaconda3** 5.3.0
 - **Docker CLI** 19.03.7
+- **Docker Compose** 1.25.4
+- **AWS CLI** Latest
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Licenses for the products installed within the images:
 - Ansible: [GPL v3.0](https://github.com/ansible/ansible/blob/devel/COPYING)
 - Google Chrome [EULA](https://www.google.com/intl/en_sg/chrome/privacy/eula_text.html)
 - Anaconda [EULA](https://docs.anaconda.com/anaconda/eula/)
+- Docker [Apache License, Version 2.0.](https://github.com/docker/docker/blob/master/LICENSE)
+- AWS [Apache License, Version 2.0.](https://github.com/aws/aws-cli/blob/develop/LICENSE.txt) 
 
 As with all Docker images, other software is likely to be included, which might be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/ci_tests.sh
+++ b/ci_tests.sh
@@ -8,3 +8,8 @@ gcloud --version
 echo "Helm version $(helm version -c --short)"
 ansible --version
 google-chrome --version
+conda --version
+python -V
+docker --version
+docker-compose --version
+aws --version

--- a/test.sh
+++ b/test.sh
@@ -11,3 +11,5 @@ docker run --rm committed/ci google-chrome --version
 docker run --rm committed/ci conda --version
 docker run --rm committed/ci python -V
 docker run --rm committed/ci docker --version
+docker run --rm committed/ci docker-compose --version
+docker run --rm committed/ci aws --version


### PR DESCRIPTION
- Updates base image to use AdoptOpenJDK 13 Ubuntu
- Adds Docker Compose tool
- Adds AWS CLI tool
- Adds drone build to ease building/testing changes
- Updates Node to latest LTS
- Updates README to include pinned tool versions, adds licence references
- Updates CI tests to include all tools

Closes #6
Closes #7